### PR TITLE
Fix "WARNING: API 'variant.getJavaCompile()' is obsolete"

### DIFF
--- a/plugin/src/main/groovy/wang/dannyhe/tools/PreprocessorPlugin.groovy
+++ b/plugin/src/main/groovy/wang/dannyhe/tools/PreprocessorPlugin.groovy
@@ -5,6 +5,7 @@ import groovy.transform.ToString
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.tasks.compile.JavaCompile
 
 public class PreprocessorPlugin implements Plugin<Project> {
 
@@ -63,7 +64,14 @@ public class PreprocessorPlugin implements Plugin<Project> {
             group global.groupName
             description "Preprocess java source code for ${processorTaskName}:${fSymbols.join(",")}"
         }
-        variant.javaCompile.dependsOn processorTaskName
+
+        JavaCompile javaCompile
+        if (variant.hasProperty('javaCompileProvider')) {
+            javaCompile = variant.javaCompileProvider.get()
+        } else {
+            javaCompile = variant.javaCompile
+        }
+        javaCompile.dependsOn processorTaskName
     }
 }
 


### PR DESCRIPTION

```
WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variant.getJavaCompile(), use -Pandroid.debug.obsoleteApi=true on the command line to display more information.
```

The fix dynamically replace 'variant.getJavaCompile()' by 'variant.getJavaCompileProvider()' when available. 
- Perform replacement on newer Android Gradle Plugins (3.3.0+)
- It keeps backwards compatibility and use 'variant.getJavaCompile()' on older Android Gradle Plugins